### PR TITLE
fix: download links for splits and dataset

### DIFF
--- a/utils/download_data.sh
+++ b/utils/download_data.sh
@@ -21,8 +21,8 @@ cp utils/download_embeddings.py $FOLDER/fast
 wget --show-progress -O $FOLDER/attr-ops-data.tar.gz https://utexas.box.com/shared/static/h7ckk2gx5ykw53h8o641no8rdyi7185g.gz
 wget --show-progress -O $FOLDER/mitstates.zip http://wednesday.csail.mit.edu/joseph_result/state_and_transformation/release_dataset.zip
 wget --show-progress -O $FOLDER/utzap.zip http://vision.cs.utexas.edu/projects/finegrained/utzap50k/ut-zap50k-images.zip
-wget --show-progress -O $FOLDER/splits.tar.gz https://www.senthilpurushwalkam.com/publication/compositional/compositional_split_natural.tar.gz
-wget --show-progress -O $FOLDER/cgqa.zip https://s3.mlcloud.uni-tuebingen.de/czsl/cgqa-updated.zip
+wget --show-progress -O $FOLDER/splits.tar.gz https://senthilpurushwalkam.com/publications/compositional/compositional_split_natural.tar.gz
+wget --show-progress -O $FOLDER/cgqa.zip https://huggingface.co/datasets/nihalnayak/cgqa/resolve/main/cgqa.zip
 
 echo "Data downloaded. Extracting files..."
 sed -i "s|ROOT_FOLDER|$FOLDER|g" utils/reorganize_utzap.py
@@ -45,7 +45,7 @@ unzip utzap.zip -d ut-zap50k/
 mv ut-zap50k/ut-zap50k-images ut-zap50k/_images/
 
 # C-GQA
-unzip cgqa.zip -d cgqa/
+unzip -q cgqa.zip
 
 # Download new splits for Purushwalkam et. al
 tar -zxvf splits.tar.gz


### PR DESCRIPTION
This PR fixes the download link for CGQA and Sendhil's compositionality splits. 

Resolve #40 